### PR TITLE
Exclude parse-double/long from Clojure 1.11

### DIFF
--- a/src/no/en/core.cljc
+++ b/src/no/en/core.cljc
@@ -1,5 +1,5 @@
 (ns no.en.core
-  (:refer-clojure :exclude [replace read-string])
+  (:refer-clojure :exclude [replace read-string parse-double parse-long])
   (:require [clojure.string :refer [blank? join replace split upper-case]]
             #?(:clj [clojure.edn :refer [read-string]])
             #?(:cljs [cljs.reader :refer [read-string]])


### PR DESCRIPTION
To remove warning when using this library with Clojure 1.11