### PR TITLE
Fix Clojure 11 warnings

### DIFF
--- a/src/no/en/core.cljc
+++ b/src/no/en/core.cljc
@@ -1,5 +1,5 @@
 (ns no.en.core
-  (:refer-clojure :exclude [replace read-string])
+  (:refer-clojure :exclude [replace read-string parse-long parse-double])
   (:require [clojure.string :refer [blank? join replace split upper-case]]
             #?(:clj [clojure.edn :refer [read-string]])
             #?(:cljs [cljs.reader :refer [read-string]])


### PR DESCRIPTION
This PR fixes the following warnings on projects using Clojure 11 that depend on noencore:

```sh
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: no.en.core, being replaced by: #'no.en.core/parse-long
WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: no.en.core, being replaced by: #'no.en.core/parse-double
```

This update can be a patch, it is not breaking.